### PR TITLE
Sync app/libs with app/android/libs

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,17 @@
+from shutil import copyfile
+from os import listdir
+
+base_path_libs = '../libs'
+
+alldir = listdir(base_path_libs)
+
+libs = list(filter(lambda x: x.endswith('.jar'), alldir))
+
+for lib in libs:
+    path_lib = base_path_libs +'/'+ lib
+    destiny_lib = './libs/' + lib
+    copyfile(path_lib, destiny_lib)
+    print(' * Lib {} imported to android/libs/'.format(lib))
+
+print(' * All libs is already imported')
+

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -13,5 +13,5 @@ for lib in libs:
     copyfile(path_lib, destiny_lib)
     print(' * Lib {} imported to android/libs/'.format(lib))
 
-print(' * All libs is already imported')
+print(' * All libs are already imported')
 


### PR DESCRIPTION
Add hook to import .jar libs in app/libs to app/android/libs, you won't need to put .jar libs directly into app/android/libs.